### PR TITLE
jade => jade-legacy

### DIFF
--- a/__mocks__/jade-legacy.js
+++ b/__mocks__/jade-legacy.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle, no-var */
 
-const jade = jest.genMockFromModule('jade');
+const jade = jest.genMockFromModule('jade-legacy');
 const compileClient = jest.fn(() => '');
 jade.compileClient = compileClient;
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jest": "^20.0.4"
   },
   "dependencies": {
-    "jade": "1.11.0"
+    "jade-legacy": "1.11.1"
   },
   "externals": {
     "jade": {

--- a/src/__snapshots__/getInfo.spec.js.snap
+++ b/src/__snapshots__/getInfo.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`getInfo method when invoking the method should return the list of dependencies 1`] = `
 Object {
-  "jade": "1.11.0",
+  "jade-legacy": "1.11.1",
 }
 `;
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-var */
 
-const jade = require('jade');
+const jade = require('jade-legacy');
 
 module.exports = (options, callback) => {
   var compiled;

--- a/src/compile.spec.js
+++ b/src/compile.spec.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const jade = require('jade');
+const jade = require('jade-legacy');
 const compile = require('./compile');
 
 describe('compile method', () => {

--- a/src/getCompiledTemplate.js
+++ b/src/getCompiledTemplate.js
@@ -1,5 +1,5 @@
 const vm = require('vm');
-const jade = require('jade/runtime.js');
+const jade = require('jade-legacy/runtime.js');
 
 module.exports = (templateString, key) => {
   const context = { jade };


### PR DESCRIPTION
jade legacy is jade with security patches.
https://github.com/jnordberg/jade-legacy

Upgrading this would help us removing the npm shrinkwrap from OC 🎉 